### PR TITLE
chore: replace `htmlSafe` with `trustHTML`

### DIFF
--- a/addon/components/avatar.gts
+++ b/addon/components/avatar.gts
@@ -1,6 +1,6 @@
 import type { TOC } from '@ember/component/template-only';
 import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
+import { trustHTML } from '@ember/template';
 import { or } from 'ember-truth-helpers';
 import Identicon from 'identicon.js';
 
@@ -32,7 +32,7 @@ const Avatar: TOC<AvatarSignature> = <template>
     src={{or @url (generateIdenticon @id)}}
     alt={{@alt}}
     class="rounded-circle"
-    style={{htmlSafe
+    style={{trustHTML
       (concat
         "object-fit: cover; width: "
         (or @size DEFAULT_SIZE)

--- a/addon/components/placeholder.gts
+++ b/addon/components/placeholder.gts
@@ -1,6 +1,6 @@
 import type { TOC } from '@ember/component/template-only';
 import { on } from '@ember/modifier';
-import { htmlSafe } from '@ember/template';
+import { trustHTML } from '@ember/template';
 import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { and } from 'ember-truth-helpers';
 import Button from './button';
@@ -25,7 +25,7 @@ const Placeholder: TOC<PlaceholderSignature> = <template>
     data-test-placeholder
     ...attributes
   >
-    <div class="text-center" style={{htmlSafe "max-width: 25rem;"}}>
+    <div class="text-center" style={{trustHTML "max-width: 25rem;"}}>
       <h1 class="mb-3">
         <Icon @icon={{@icon}} />
       </h1>

--- a/addon/components/progress/bar.gts
+++ b/addon/components/progress/bar.gts
@@ -1,5 +1,5 @@
 import { concat } from '@ember/helper';
-import { type SafeString, htmlSafe } from '@ember/template';
+import { trustHTML } from '@ember/template';
 import Component from '@glimmer/component';
 
 export interface ProgressBarSignature {
@@ -14,8 +14,8 @@ export interface ProgressBarSignature {
 }
 
 export default class ProgressBar extends Component<ProgressBarSignature> {
-  get style(): SafeString {
-    return htmlSafe(`width: ${(this.args.value * 100).toString()}%;`);
+  get style() {
+    return trustHTML(`width: ${(this.args.value * 100).toString()}%;`);
   }
 
   <template>


### PR DESCRIPTION
Fixes #213 